### PR TITLE
refactor: add class-based global styling

### DIFF
--- a/elevate-client/src/app/components/header/header.component.html
+++ b/elevate-client/src/app/components/header/header.component.html
@@ -1,14 +1,14 @@
 <nav>
   <a class="logo-container" routerLink="/">
     <img src="/logo.png" alt="" class="logo" />
-    <h2>Elevate</h2>
+    <h2 class="heading">Elevate</h2>
   </a>
-  <a routerLink="/">Home</a>
-  <a routerLink="/profile">Profile</a>
-  <a routerLink="/friends">Friends</a>
-  <a routerLink="/register" *ngIf="!auth.isLoggedin()">Register</a>
-  <a routerLink="/login" *ngIf="!auth.isLoggedin()">Login</a>
+  <a routerLink="/" class="app-link">Home</a>
+  <a routerLink="/profile" class="app-link">Profile</a>
+  <a routerLink="/friends" class="app-link">Friends</a>
+  <a routerLink="/register" class="app-link" *ngIf="!auth.isLoggedin()">Register</a>
+  <a routerLink="/login" class="app-link" *ngIf="!auth.isLoggedin()">Login</a>
 
 
-  <button *ngIf="auth.isLoggedin()" (click)="logout()">Logout</button>
+  <button *ngIf="auth.isLoggedin()" (click)="logout()" class="app-btn outline">Logout</button>
 </nav>

--- a/elevate-client/src/app/home/home.component.html
+++ b/elevate-client/src/app/home/home.component.html
@@ -1,12 +1,12 @@
 <div>
 
-      <button type="button"
+      <button type="button" class="app-btn"
               (click)="showAddForm = !showAddForm">
         + Log Today's Lift
       </button>
   <div class="cal-header">
 
-    <h2 class="cal-title">
+    <h2 class="cal-title heading">
       {{ viewDate | calendarDate:(view + 'ViewTitle') }}
     </h2>
 
@@ -57,12 +57,12 @@
       <form #registerForm="ngForm" (ngSubmit)="createLog(); showAddForm = false">
 
         <!-- Lift & variation -->
-        <select name="liftType" [(ngModel)]="newLift.liftType" required>
+        <select class="form-control" name="liftType" [(ngModel)]="newLift.liftType" required>
           <option value="" disabled selected hidden>Select Lift</option>
           <option *ngFor="let lift of liftOptions" [value]="lift.value">{{ lift.label }}</option>
         </select>
 
-        <input name="variation"
+        <input class="form-control" name="variation"
                type="text"
                placeholder="Variation (eg Inclined, Weighted...)"
                [(ngModel)]="newLift.variation"
@@ -70,18 +70,18 @@
 
         <!-- Sets -->
         <div class="set-row" *ngFor="let set of sets; let i = index">
-          <input  type="number"
+          <input class="form-control" type="number"
                   placeholder="Weight (kg)"
                   [(ngModel)]="sets[i].weight" [name]="'weight'+i" required>
-          <input  type="number"
+          <input class="form-control" type="number"
                   placeholder="Reps"
                   [(ngModel)]="sets[i].reps" [name]="'reps'+i" required>
           <button type="button" (click)="sets.splice(i,1)" *ngIf="sets.length>1" class="delete">✕</button>
         </div>
 
-        <button type="button" (click)="sets.push({weight:null,reps:null})">+ Add Set</button>
+        <button type="button" class="app-btn" (click)="sets.push({weight:null,reps:null})">+ Add Set</button>
         <br><br>
-        <button type="submit">Submit Log</button>
+        <button type="submit" class="app-btn">Submit Log</button>
       </form>
     </section>
   </ng-container>

--- a/elevate-client/src/app/pages/friends/friends.component.html
+++ b/elevate-client/src/app/pages/friends/friends.component.html
@@ -15,13 +15,13 @@
       <div class="search-bar">
         <form (ngSubmit)="findUser()">
           <input type="search" class="form-control" [(ngModel)]="friendToSearch" name="friend" placeholder="Enter username…">
-          <button>Search</button>
+          <button class="app-btn">Search</button>
         </form>
       </div>
 
       <div *ngIf="searchResult" class="search-res">
         <span>{{ searchResult.username }}</span>
-        <button (click)="sendRequest(searchResult.id)" [disabled]="pendingAdd">
+        <button class="app-btn outline" (click)="sendRequest(searchResult.id)" [disabled]="pendingAdd">
           {{ pendingAdd ? 'Pending' : 'Add Friend' }}
         </button>
       </div>
@@ -41,7 +41,7 @@
 
 
 <section *ngIf="tab==='friends'">
-  <h2>Your Friends</h2>
+  <h2 class="heading">Your Friends</h2>
 
   <div class="friend-list" *ngIf="friends.length; else noFriends">
     <article *ngFor="let f of friends" class="friend-card">
@@ -71,7 +71,7 @@
 </section>
 
 <section *ngIf="tab==='requests'">
-  <h2>Incoming Requests</h2>
+  <h2 class="heading">Incoming Requests</h2>
 
   <ul class="request-list" *ngIf="incoming.length; else noReq">
     <li *ngFor="let r of incoming" class="request-tube">

--- a/elevate-client/src/app/pages/login/login.component.html
+++ b/elevate-client/src/app/pages/login/login.component.html
@@ -1,16 +1,16 @@
 <div>
   <form (ngSubmit)="onSubmit()" #registerForm="ngForm">
-    <h2>Login</h2><br>
-    <input type='text' placeholder = 'Username' [(ngModel)]="credentials.username" name ='username' required><br>
+    <h2 class="heading">Login</h2><br>
+    <input class="form-control" type='text' placeholder = 'Username' [(ngModel)]="credentials.username" name ='username' required><br>
     <div class="password-row">
-      <input [type] = "showPassword? 'text': 'password'" placeholder = 'Password ' [(ngModel)]="credentials.password" name ='password' required>
-      <button type="button" (click)="showPassword = !showPassword">
+      <input class="form-control" [type] = "showPassword? 'text': 'password'" placeholder = 'Password ' [(ngModel)]="credentials.password" name ='password' required>
+      <button type="button" class="app-btn outline" (click)="showPassword = !showPassword">
         {{showPassword?'Hide': 'Show'}}
       </button>
     </div>
 
     <br>
-    <button class="enter" type='submit'>Login</button>
+    <button class="app-btn" type='submit'>Login</button>
     <div id="googleBtn"></div>
   </form>
 </div>

--- a/elevate-client/src/app/pages/profile/profile.component.html
+++ b/elevate-client/src/app/pages/profile/profile.component.html
@@ -1,5 +1,5 @@
 <div *ngIf="userProfile.username">
-    <h2>Profile</h2>
+    <h2 class="heading">Profile</h2>
   <!-- info icon -->
 <!--  <span class="info-icon"-->
 <!--        (click)="showInfo = !showInfo"-->
@@ -83,7 +83,7 @@
     <!-- edit button row -->
     <div class="btn-row-right">
       <!-- Edit button stays the same -->
-      <button class="edit-btn" (click)="isEditing = true">Edit Profile</button>
+      <button class="edit-btn app-btn outline" (click)="isEditing = true">Edit Profile</button>
 
       <!-- pop-up: *only* when biometrics are incomplete and showInfo is true -->
 <!--      <div *ngIf="biometricsIncomplete && showInfo"-->
@@ -107,21 +107,21 @@
       <div class="card">
         <label>
           <span class="label">Username</span>
-          <input class="value" type="text" [(ngModel)]="updatedProfile.username" name="username">
+          <input class="value form-control" type="text" [(ngModel)]="updatedProfile.username" name="username">
         </label>
       </div>
 
       <div class="card">
       <label>
         <span class="label">Email</span>
-        <input class="value" type="email" [(ngModel)]="updatedProfile.email" name="email">
+        <input class="value form-control" type="email" [(ngModel)]="updatedProfile.email" name="email">
       </label>
       </div>
 
       <div class="card">
         <label>
           <span class="label">Preferred Units</span>
-          <select class="value" [(ngModel)]="updatedProfile.preferredUnitSystem" name="units">
+          <select class="value form-control" [(ngModel)]="updatedProfile.preferredUnitSystem" name="units">
             <option class="value" value="" disabled selected hidden>Select unit system</option>
             <option class="value" *ngFor="let u of unitOptions" [value]="u.value">
               {{ u.label }}
@@ -134,7 +134,7 @@
       <div class="card">
         <label>
           <span class="label">Gender</span>
-          <select class="value"[(ngModel)]="updatedProfile.gender" name="gender">
+          <select class="value form-control"[(ngModel)]="updatedProfile.gender" name="gender">
             <option class="value" value="" disabled selected hidden>Select gender</option>
             <option class="value" *ngFor="let g of genderOptions" [value]="g.value">
               {{ g.label }}
@@ -146,28 +146,28 @@
       <div class="card">
         <label>
           <span class="label">Age</span>
-          <input class="value" type="number" [(ngModel)]="updatedProfile.age" name="age">
+          <input class="value form-control" type="number" [(ngModel)]="updatedProfile.age" name="age">
         </label>
       </div>
 
       <div class="card">
         <label>
           <span class="label">Weight</span>
-          <input class="value" type="number" [(ngModel)]="updatedProfile.weight" name="weight">
+          <input class="value form-control" type="number" [(ngModel)]="updatedProfile.weight" name="weight">
         </label>
       </div>
 
       <div class="card">
         <label>
           <span class="label">Height</span>
-          <input class="value" type="number" [(ngModel)]="updatedProfile.height" name="height">
+          <input class="value form-control" type="number" [(ngModel)]="updatedProfile.height" name="height">
         </label>
       </div>
     </div>
 
     <div class="btn-row">
-      <button type="submit" class="primary">Save</button>
-      <button type="button" (click)="isEditing = false">Cancel</button>
+      <button type="submit" class="app-btn">Save</button>
+      <button type="button" class="app-btn outline" (click)="isEditing = false">Cancel</button>
     </div>
   </form>
 

--- a/elevate-client/src/app/pages/register/register.component.html
+++ b/elevate-client/src/app/pages/register/register.component.html
@@ -1,16 +1,16 @@
 <form (ngSubmit)="onSubmit()" #registerForm="ngForm">
-  <h2>Register</h2><br>
+  <h2 class="heading">Register</h2><br>
   <div *ngIf="username.invalid && username.touched" style="color:red">
     Username must be 5–20 characters.
   </div>
-  <input type='text' placeholder='Username' [(ngModel)]="formData.username" name='username'
+  <input class="form-control" type='text' placeholder='Username' [(ngModel)]="formData.username" name='username'
          required minlength="5" maxlength="20"
          #username="ngModel"><br>
 
   <div *ngIf="email.invalid && email.touched" style="color:red">
     Valid email required.
   </div>
-  <input type='email' placeholder='Email' [(ngModel)]="formData.email" name='email'
+  <input class="form-control" type='email' placeholder='Email' [(ngModel)]="formData.email" name='email'
          required
          #email="ngModel"><br>
 
@@ -18,14 +18,14 @@
     <div *ngIf="password.invalid && password.touched" style="color:red">
       Password must be at least 5 characters.
     </div>
-    <input [type]="showPassword ? 'text' : 'password'" placeholder='Password' [(ngModel)]="formData.password" name='password'
+    <input class="form-control" [type]="showPassword ? 'text' : 'password'" placeholder='Password' [(ngModel)]="formData.password" name='password'
            required minlength="5"
            #password="ngModel">
-    <button type="button" (click)="showPassword = !showPassword">{{ showPassword ? 'Hide' : 'Show' }}</button>
+    <button type="button" class="app-btn outline" (click)="showPassword = !showPassword">{{ showPassword ? 'Hide' : 'Show' }}</button>
   </div>
   <br>
 
-  <button type='submit' class="enter" [disabled]="registerForm.invalid">Register</button>
+  <button type='submit' class="app-btn" [disabled]="registerForm.invalid">Register</button>
 
   <div id="googleBtn"></div>
 </form>

--- a/elevate-client/src/index.html
+++ b/elevate-client/src/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="logo.png">
 </head>
-<body>
+<body class="app-body">
   <app-root></app-root>
   <script src="https://accounts.google.com/gsi/client" async defer></script>
 </body>

--- a/elevate-client/src/styles.scss
+++ b/elevate-client/src/styles.scss
@@ -8,30 +8,34 @@
 
 
 
-body {
+body.app-body {
   font-family: Arial, sans-serif;
   background-color: white;
   margin: 0;
   padding: 0;
   color: #333;
-
 }
 
-a {
+.app-link {
   text-decoration: none;
-  padding: 2%;
-  font-size: 1.4rem;
+  padding: 0.5rem;
+  font-size: 1.2rem;
   color: var(--gray-900);
   font-weight: 500;
   line-height: 100%;
-  letter-spacing: -0.125rem;
+  letter-spacing: -0.05rem;
   margin: 0;
   font-family: "Inter Tight", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-  Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
-  "Segoe UI Symbol";
+    Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
+    "Segoe UI Symbol";
+  transition: color 0.2s;
+
+  &:hover {
+    color: #007bff;
+  }
 }
 
-h2 {
+.heading {
   font-size: 2.25rem;
   color: var(--gray-900);
   font-weight: 500;
@@ -39,40 +43,49 @@ h2 {
   letter-spacing: -0.075rem;
   margin: 0;
   font-family: "Inter Tight", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-  Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
-  "Segoe UI Symbol";
+    Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
+    "Segoe UI Symbol";
 }
 
-button {
-
+.app-btn {
   border: none;
   padding: 0.5rem 1rem;
-  border-radius: 0;
+  border-radius: 4px;
   cursor: pointer;
-  background-color: white;
-
+  background-color: #007bff;
   font-size: 1.1rem;
-  color: var(--gray-900);
+  color: #fff;
   font-weight: 500;
   line-height: 100%;
   letter-spacing: -0.075rem;
   margin: 0;
   font-family: "Inter Tight", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-  Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
-  "Segoe UI Symbol";
+    Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
+    "Segoe UI Symbol";
+  transition: background-color 0.2s;
 
   &:hover {
-    color: #007bff;
+    background-color: #0056b3;
   }
 
   &:disabled {
-    background-color: white;
+    background-color: #ccc;
     cursor: not-allowed;
+  }
+
+  &.outline {
+    background-color: transparent;
+    color: #007bff;
+    border: 1px solid #007bff;
+
+    &:hover {
+      background-color: #007bff;
+      color: #fff;
+    }
   }
 }
 
-input,
-select {
+.form-control {
   padding: 0.5rem;
   margin-top: 0.25rem;
   margin-bottom: 1rem;


### PR DESCRIPTION
## Summary
- switch global element selectors to reusable CSS classes
- apply new classes across templates for links, headings, buttons and inputs

## Testing
- `npm test -- --watch=false` *(fails: Found 1 load error)*

------
https://chatgpt.com/codex/tasks/task_e_68a64df687d88324a66652055ad51176